### PR TITLE
Add parser factory and config-driven branding

### DIFF
--- a/public/config.json
+++ b/public/config.json
@@ -1,11 +1,14 @@
 {
   "general": {
     "displaySubmissionId": true,
-    "parser": "playstationParser"
+    "platform": "PlayStation",
+    "parser": "playstationParser",
+    "fileExtensions": [".xlsx"]
   },
   "header": {
     "title": "Universal Digital Donor",
-    "logo": "/playstation-svgrepo-com.svg"
+    "logo": "/playstation-svgrepo-com.svg",
+    "logoAlt": "PlayStation Logo"
   },
   "page": {
     "consent": {

--- a/src/App.test.js
+++ b/src/App.test.js
@@ -1,13 +1,18 @@
 import { render, screen } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import App from './App';
+import { ConfigContext } from './ConfigContext';
+import config from '../public/config.json';
 
 test('renders consent page on initial load', () => {
   render(
-    <MemoryRouter>
-      <App />
-    </MemoryRouter>
+    <ConfigContext.Provider value={config}>
+      <MemoryRouter>
+        <App />
+      </MemoryRouter>
+    </ConfigContext.Provider>
   );
   const linkElement = screen.getByText(/I have read and agree with the above terms/i);
   expect(linkElement).toBeInTheDocument();
 });
+

--- a/src/pages/ConsentPage.js
+++ b/src/pages/ConsentPage.js
@@ -23,8 +23,8 @@ const ConsentPage = () => {
         <div className="card-header">
           <div className="d-flex align-items-center gap-3">
             <img
-              src={process.env.PUBLIC_URL + "/playstation-svgrepo-com.svg"}
-              alt="PlayStation Logo"
+              src={process.env.PUBLIC_URL + config.header.logo}
+              alt={config.header.logoAlt}
               width="40"
               height="40"
               style={{ flexShrink: 0, marginRight: '12px' }}
@@ -66,4 +66,5 @@ const ConsentPage = () => {
   );
 };
 
-export default ConsentPage;
+export default ConsentPage
+

--- a/src/pages/UploadPage.js
+++ b/src/pages/UploadPage.js
@@ -4,7 +4,7 @@ import Button from '@mui/material/Button';
 import CircularProgress from '@mui/material/CircularProgress';
 import Alert from '@mui/material/Alert';
 import AlertTitle from '@mui/material/AlertTitle';
-import { parsePlaystationFile } from '../parsers/playstationParser';
+import { getParser } from '../utils/parserFactory';
 import { useConfig } from '../ConfigContext';
 
 const UploadPage = ({ setParsedData }) => {
@@ -50,8 +50,10 @@ const UploadPage = ({ setParsedData }) => {
     if (file) {
       setLoading(true);
       try {
+        // Dynamically load the parser based on config
+        const parser = await getParser(config.general.parser);
         // Parse the file before navigating
-        const parseResult = await parsePlaystationFile(file);
+        const parseResult = await parser(file);
         const parsed = parseResult.data;
         const parsingErrors = parseResult.parsingErrors;
         
@@ -135,7 +137,7 @@ const UploadPage = ({ setParsedData }) => {
                 type="file"
                 hidden
                 onChange={handleFileChange}
-                accept=".xlsx"
+                accept={config.general.fileExtensions.join(',')}
               />
             </Button>
           </div>
@@ -220,4 +222,4 @@ const UploadPage = ({ setParsedData }) => {
   );
 };
 
-export default UploadPage;
+export default UploadPage

--- a/src/pages/UploadPage.test.js
+++ b/src/pages/UploadPage.test.js
@@ -2,10 +2,16 @@ import React from 'react';
 import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { BrowserRouter } from 'react-router-dom';
 import UploadPage from './UploadPage';
-import { parsePlaystationFile } from '../parsers/playstationParser';
+import { getParser } from '../utils/parserFactory';
+import { ConfigContext } from '../ConfigContext';
+import config from '../../public/config.json';
 
-// Mock the parser
-jest.mock('../parsers/playstationParser');
+// Mock the parser factory to return a mocked parser function
+jest.mock('../utils/parserFactory');
+
+// Mock parser function that will be returned by getParser
+const mockParser = jest.fn();
+
 
 const mockSetParsedData = jest.fn();
 const mockNavigate = jest.fn();
@@ -18,15 +24,18 @@ jest.mock('react-router-dom', () => ({
 
 const renderUploadPage = () => {
   return render(
-    <BrowserRouter>
-      <UploadPage setParsedData={mockSetParsedData} />
-    </BrowserRouter>
+    <ConfigContext.Provider value={config}>
+      <BrowserRouter>
+        <UploadPage setParsedData={mockSetParsedData} />
+      </BrowserRouter>
+    </ConfigContext.Provider>
   );
 };
 
 describe('UploadPage Failsafe', () => {
   beforeEach(() => {
     jest.clearAllMocks();
+    getParser.mockResolvedValue(mockParser);
   });
 
   it('should show warning when no sheets contain data', async () => {
@@ -73,7 +82,7 @@ describe('UploadPage Failsafe', () => {
       }
     };
 
-    parsePlaystationFile.mockResolvedValue(mockParseResult);
+    mockParser.mockResolvedValue(mockParseResult);
 
     renderUploadPage();
 
@@ -135,7 +144,7 @@ describe('UploadPage Failsafe', () => {
       }
     };
 
-    parsePlaystationFile.mockResolvedValue(mockParseResult);
+    mockParser.mockResolvedValue(mockParseResult);
 
     renderUploadPage();
 
@@ -188,7 +197,7 @@ describe('UploadPage Failsafe', () => {
       }
     };
 
-    parsePlaystationFile.mockResolvedValue(mockParseResult);
+    mockParser.mockResolvedValue(mockParseResult);
 
     renderUploadPage();
 
@@ -214,4 +223,5 @@ describe('UploadPage Failsafe', () => {
     // Verify that navigation was not called (user should see warning first)
     expect(mockNavigate).not.toHaveBeenCalled();
   });
-}); 
+});
+

--- a/src/parsers/playstationParser.js
+++ b/src/parsers/playstationParser.js
@@ -310,3 +310,5 @@ export const filterData = (parsedData, filters) => {
   }
   return filteredData;
 };
+
+export default parsePlaystationFile;

--- a/src/parsers/playstationParser.test.js
+++ b/src/parsers/playstationParser.test.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 describe('playstationParser', () => {
   it('should parse the Playstation Excel file and extract the correct columns', async () => {
-    const filePath = path.resolve(__dirname, '../../tests/sonyJun24.xlsx');
+    const filePath = path.resolve(__dirname, '../../tests/sonysample.xlsx');
     const parseResult = await parsePlaystationFile(filePath);
 
     // Expect the parser to return an object with data and parsingErrors
@@ -61,7 +61,7 @@ describe('playstationParser', () => {
   });
 
   it('should track parsing errors correctly', async () => {
-    const filePath = path.resolve(__dirname, '../../tests/sonyJun24.xlsx');
+    const filePath = path.resolve(__dirname, '../../tests/sonysample.xlsx');
     const parseResult = await parsePlaystationFile(filePath);
 
     // Verify parsing errors structure

--- a/src/parsers/playstationParserNew.test.js
+++ b/src/parsers/playstationParserNew.test.js
@@ -3,7 +3,7 @@ import path from 'path';
 
 describe('playstationParser', () => {
   it('should parse the PlayStation file successfully', async () => {
-    const filePath = path.resolve(__dirname, '../../tests/sonyJun24.xlsx');
+    const filePath = path.resolve(__dirname, '../../tests/sonysample.xlsx');
     const parseResult = await parsePlaystationFile(filePath);
 
     // Test that the parser returns an object with parsed data and parsing errors

--- a/src/utils/parserFactory.js
+++ b/src/utils/parserFactory.js
@@ -1,0 +1,8 @@
+export const getParser = async (parserName) => {
+  if (!parserName) {
+    throw new Error('Parser name not provided');
+  }
+  const module = await import(`../parsers/${parserName}.js`);
+  return module.default;
+};
+


### PR DESCRIPTION
## Summary
- implement dynamic parser loader with new `getParser` utility
- make parser configurable in `UploadPage`
- use logo path from configuration in `ConsentPage`
- add tests with configuration provider
- update parser tests to use sample Excel file

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_b_6877bbda333c83318271221238436cbe